### PR TITLE
fix: emit package type declarations

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
         'cli/index': 'src/cli/index.ts',
     },
     format: ['esm'],
-    dts: false,
+    dts: true,
     clean: true,
     sourcemap: true,
     splitting: false,


### PR DESCRIPTION
## Summary
- enable tsup declaration generation so the package emits the advertised `dist/index.d.ts`
- keeps the existing ESM output, exports map, and package files unchanged

## Validation
- `npm run typecheck`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build`
- `npm pack --dry-run --json --ignore-scripts` includes `dist/index.d.ts`
- local ESM consumer install from the packed tarball passes `npx tsc --noEmit --pretty false`

Fixes #6